### PR TITLE
Introduces asciipipe, z/OS environment defaults

### DIFF
--- a/bin/perlbuild.sh
+++ b/bin/perlbuild.sh
@@ -51,7 +51,12 @@ PERLPORT_ROOT="${PWD}"
 
 perlbld="${PERL_VRM}.${PERL_OS390_TGT_AMODE}.${PERL_OS390_TGT_LINK}.${PERL_OS390_TGT_CODEPAGE}"
 
-ConfigOpts="-Dprefix=/usr/local/perl/${perlbld}"
+if [ ! -z "${CONFIG_OPTS}" ]; then
+  ConfigOpts="$CONFIG_OPTS"
+else
+  ConfigOpts="-Dprefix=/usr/local/perl/${perlbld}"
+fi
+echo $ConfigOpts
 case "$PERL_VRM" in
 	maint*) ConfigOpts="${ConfigOpts} -de" ;;
 	blead) ConfigOpts="${ConfigOpts} -des -Dusedevel" ;;

--- a/bin/perlbuild.sh
+++ b/bin/perlbuild.sh
@@ -129,7 +129,7 @@ fi
 echo "Make Perl"
 date
 
-nohup make >/tmp/make.${USER}.${perlbld}.out 2>&1
+nohup make -j6 >/tmp/make.${USER}.${perlbld}.out 2>&1
 rc=$?
 if [ $rc -gt 0 ]; then
 	echo "MAKE of Perl tree failed." >&2
@@ -147,7 +147,7 @@ else
 	echo "Make Test Perl"
 	date
 
-	nohup make test >/tmp/maketest.${USER}.${perlbld}.out 2>&1
+	nohup make -j6 test >/tmp/maketest.${USER}.${perlbld}.out 2>&1
 	rc=$?
 	if [ $rc -gt 0 ]; then
 		echo "MAKE test of Perl tree failed." >&2

--- a/blead/patches/doio.c.patchascii
+++ b/blead/patches/doio.c.patchascii
@@ -1,0 +1,39 @@
+***************
+*** 246,252 ****
+      }
+  
+      int asciiopen(const char* path, int oflag) 
+      {
+-       int rc;
+        int fd = open(path, oflag);
+        if (fd == -1) { 
+--- 246,262 ----
+      }
+  
++     int asciipipe(int fd[2])
++     {
++       int f = pipe(fd);
++       if (f == -1) { 
++         return f;
++       }
++       setccsid(fd[0], 819);
++       setccsid(fd[1], 819);
++       return f; 
++     }
++ 
+      int asciiopen(const char* path, int oflag) 
+      {
+        int fd = open(path, oflag);
+        if (fd == -1) { 
+***************
+*** 2505,2508 ****
+--- 2515,2523 ----
+            doshell:
+              PERL_FPU_PRE_EXEC
++ #if defined(OEMVS)
++   #if (__CHARSET_LIB == 1)
++             unsetenv("_TAG_REDIR_ERR");
++   #endif
++ #endif
+              PerlProc_execl(PL_sh_path, "sh", "-c", cmd, (char *)NULL);
+              PERL_FPU_POST_EXEC

--- a/blead/patches/ext/Errno/Errno_pm.PL.oldpatch
+++ b/blead/patches/ext/Errno/Errno_pm.PL.oldpatch
@@ -1,0 +1,17 @@
+***************
+*** 132,140 ****
+      } elsif ($^O eq 'os390') {
+  	# OS/390 C compiler doesn't generate #file or #line directives
+!         # and it does not tag the header as 1047 (EBCDIC), so make a local
+!         # copy and tag it
+!         my $cp = `cp /usr/include/errno.h ./errno.h`;
+!         my $chtag = `chtag -t -cIBM-1047 ./errno.h`;
+! 	$file{'./errno.h'} = 1;
+      } elsif ($Config{archname} eq 'arm-riscos') {
+  	# Watch out for cross compiling for RISC OS
+--- 132,136 ----
+      } elsif ($^O eq 'os390') {
+  	# OS/390 C compiler doesn't generate #file or #line directives
+! 	$file{'/usr/include/errno.h'} = 1;
+      } elsif ($Config{archname} eq 'arm-riscos') {
+  	# Watch out for cross compiling for RISC OS

--- a/blead/patches/ext/ExtUtils-Miniperl/lib/ExtUtils/Miniperl.pm.patchascii
+++ b/blead/patches/ext/ExtUtils-Miniperl/lib/ExtUtils/Miniperl.pm.patchascii
@@ -1,0 +1,69 @@
+***************
+*** 69,72 ****
+--- 69,76 ----
+  
+  #ifdef OEMVS
++ #include <_Nascii.h>
++ #include <sys/stat.h>
++ #include <fcntl.h>
++ #ifndef __LP64__
+  #ifdef MYMALLOC
+  /* sbrk is limited to first heap segment so make it big */
+***************
+*** 76,80 ****
+--- 80,114 ----
+  #endif
+  #endif
++ int __getfdccsid(int fd) {
++   struct stat st;
++   int rc;
++   rc = fstat(fd, &st);
++   if (rc != 0)
++     return -1;
++   unsigned short ccsid = st.st_tag.ft_ccsid;
++   if (st.st_tag.ft_txtflag) {
++     return 65536 + ccsid;
++   }
++   return ccsid;
++ }
+  
++ void __set_autocvt_on_fd_stream(int fd, unsigned short ccsid,
++                                 unsigned char txtflag, int on_untagged_only) {
++   struct file_tag tag;
++ 
++   tag.ft_ccsid = ccsid;
++   tag.ft_txtflag = txtflag;
++   tag.ft_deferred = 0;
++   tag.ft_rsvflags = 0;
++ 
++   struct f_cnvrt req = {SETCVTON, 0, (short)ccsid};
++ 
++   if (!on_untagged_only || (!isatty(fd) && 0 == __getfdccsid(fd))) {
++     fcntl(fd, F_CONTROL_CVT, &req);
++     fcntl(fd, F_SETTAG, &tag);
++   }
++ }
++ #endif
++ 
+  #define PERL_IN_MINIPERLMAIN_C
+  
+***************
+*** 103,106 ****
+--- 137,153 ----
+      PL_use_safe_putenv = FALSE;
+  #endif /* PERL_USE_SAFE_PUTENV */
++ 
++ #ifdef OEMVS
++ #if (__CHARSET_LIB == 1)
++   __ae_thread_swapmode(__AE_ASCII_MODE);
++   __ae_autoconvert_state(_CVTSTATE_ON);
++   setenv("_TAG_REDIR_IN", "txt", 0);
++   setenv("_TAG_REDIR_OUT", "txt", 0);
++   setenv("_TAG_REDIR_ERR", "txt", 0);
++   __set_autocvt_on_fd_stream(STDIN_FILENO, 1047, 1, true);
++   __set_autocvt_on_fd_stream(STDERR_FILENO, 1047, 1, true);
++   __set_autocvt_on_fd_stream(STDOUT_FILENO, 1047, 1, true);
++ #endif
++ #endif
+  
+      /* if user wants control of gprof profiling off by default */

--- a/blead/patches/iperlsys.h.patchascii
+++ b/blead/patches/iperlsys.h.patchascii
@@ -1,0 +1,23 @@
+***************
+*** 1118,1122 ****
+  #define PerlProc_popen_list(m,n,a)	my_popen_list((m),(n),(a))
+  #define PerlProc_pclose(f)	my_pclose((f))
+! #define PerlProc_pipe(fd)	pipe((fd))
+  #define PerlProc_setuid(u)	setuid((u))
+  #define PerlProc_setgid(g)	setgid((g))
+--- 1118,1132 ----
+  #define PerlProc_popen_list(m,n,a)	my_popen_list((m),(n),(a))
+  #define PerlProc_pclose(f)	my_pclose((f))
+! #if defined(OEMVS)
+!   #if (__CHARSET_LIB == 1)
+!     int asciipipe(int fd[2]);
+! 
+!     #define PerlProc_pipe(fd)	asciipipe((fd))
+!   #else
+!     #define PerlProc_pipe(fd)	pipe((fd))
+!   #endif
+! #else
+!   #define PerlProc_pipe(fd)	pipe((fd))
+! #endif
+  #define PerlProc_setuid(u)	setuid((u))
+  #define PerlProc_setgid(g)	setgid((g))

--- a/blead/patches/util.c.patchascii
+++ b/blead/patches/util.c.patchascii
@@ -1,0 +1,46 @@
+***************
+*** 2710,2719 ****
+          if (did_pipes)
+              PerlLIO_close(pp[0]);
+- #if defined(OEMVS)
+-   #if (__CHARSET_LIB == 1)
+-         chgfdccsid(p[THIS], 819);
+-         chgfdccsid(p[THAT], 819);
+-   #endif
+- #endif
+          /* Now dup our end of _the_ pipe to right position */
+          if (p[THIS] != (*mode == 'r')) {
+--- 2710,2713 ----
+***************
+*** 2791,2807 ****
+      if (did_pipes)
+           PerlLIO_close(pp[0]);
+- #if defined(OEMVS)
+-   #if (__CHARSET_LIB == 1)
+-     PerlIO* io = PerlIO_fdopen(p[This], mode);
+-     if (io) {
+-       chgfdccsid(p[This], 819);
+-     }
+-     return io;
+-   #else
+      return PerlIO_fdopen(p[This], mode);
+-   #endif
+- #else
+-     return PerlIO_fdopen(p[This], mode);
+- #endif
+  
+  #else
+--- 2785,2789 ----
+***************
+*** 2871,2880 ****
+          if (did_pipes)
+              PerlLIO_close(pp[0]);
+- #if defined(OEMVS)
+-   #if (__CHARSET_LIB == 1)
+-         chgfdccsid(p[THIS], 819);
+-         chgfdccsid(p[THAT], 819);
+-   #endif
+- #endif
+          if (p[THIS] != (*mode == 'r')) {
+              PerlLIO_dup2(p[THIS], *mode == 'r');
+--- 2853,2856 ----


### PR DESCRIPTION
* Adds config opts to override -Dprefix
* Adds asciipipe for z/OS ascii so that we don't need to find all places that pipes are created and tag them
* Fixes an issue with sh and stderr redirection by unsetting _TAG_REDIR_ERR because it seems to create a case of double conversion...could be a sh bug?
* Sets _TAG_REDIR_IN/OUT/ERR by default as well as autocvt state so that we don't need to specify the envars
* Sets the STDIO fds to 1047, in case they are untagged

Number of failures should now be 23 in the ASCII build