### PR TITLE
Add README, determine num build jobs, libpath corrections

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,9 @@
+export _BPXK_AUTOCVT=ON
+export _CEE_RUNOPTS="$_CEE_RUNOPTS FILETAG(AUTOCVT,AUTOTAG) POSIX(ON)"
+export _TAG_REDIR_IN=txt
+export _TAG_REDIR_ERR=txt
+export _TAG_REDIR_OUT=txt
+if [ -d $PERL_INSTALL_DIR ]; then
+  export PATH="${PERL_INSTALL_DIR}/bin:$PATH"
+  export PERL5LIB="${PERL_INSTALL_DIR}/lib"
+fi

--- a/README_ZOS.md
+++ b/README_ZOS.md
@@ -1,0 +1,18 @@
+# z/OS Perl
+
+# System Requirements
+- z/OS V2R1 and above
+- z196 and above
+  - z/OS UNIX with Enhanced ASCII activated
+
+# How to use:
+- Set environment variables
+  - Source the `/path/to/perl/.env` file
+- Run `perl --version`
+- Run a Perl Hello world program:
+- Create a `hello.perl` file with the following contents:
+```perl
+print("Hello, World!\n");
+```
+- Run `perl hello.perl`
+

--- a/README_ZOS.md
+++ b/README_ZOS.md
@@ -7,9 +7,13 @@
 
 # How to use:
 - Set environment variables
-  - Source the `/path/to/perl/.env` file
-- Run `perl --version`
-- Run a Perl Hello world program:
+  - Set PERL_INSTALL_DIR to the perl install directory
+  - Then, source the `.env` file: 
+```sh
+. $PERL_INSTALL_DIR/.env
+```
+- Run `perl --version` to verify that the correct version is installed
+- Run a Perl "Hello World" program:
 - Create a `hello.perl` file with the following contents:
 ```perl
 print("Hello, World!\n");

--- a/bin/numcpus.rexx
+++ b/bin/numcpus.rexx
@@ -1,0 +1,3 @@
+/* REXX */
+x = SYSCPUS('CPUS.')
+say CPUS.0

--- a/bin/perlbuild.sh
+++ b/bin/perlbuild.sh
@@ -147,7 +147,22 @@ echo "Make Perl"
 date
 
 
-nohup make -j4 >${PERL_OS390_TGT_LOG_DIR}/make.${USER}.${perlbld}.out 2>&1
+numcpus=`numcpus.rexx`
+numjobs=1;
+if [ $? -eq 0 ]; then
+  numjobs="${numcpus}"
+fi
+
+# cap to 8 to avoid impacting others on a large system
+if [ $numjobs -gt 8 ]; then
+  numjobs=8
+fi
+
+if [ ! -z "${PERL_NUM_JOBS}" ]; then
+  numjobs=${PERL_NUM_JOBS}
+fi
+
+nohup make -j"${numjobs}" >${PERL_OS390_TGT_LOG_DIR}/make.${USER}.${perlbld}.out 2>&1
 
 rc=$?
 if [ $rc -gt 0 ]; then
@@ -167,7 +182,7 @@ else
 	date
 
 
-	nohup make test >${PERL_OS390_TGT_LOG_DIR}/maketest.${USER}.${perlbld}.out 2>&1
+	TEST_JOBS="${numjobs}" nohup make test >${PERL_OS390_TGT_LOG_DIR}/maketest.${USER}.${perlbld}.out 2>&1
 
 	rc=$?
 	if [ $rc -gt 0 ]; then

--- a/blead/patches/002.patch
+++ b/blead/patches/002.patch
@@ -1,9 +1,9 @@
 diff --git a/os390/os390.c b/os390/os390.c
 new file mode 100644
-index 0000000..6d4e6c2
+index 0000000..5d8f7dc
 --- /dev/null
 +++ b/os390/os390.c
-@@ -0,0 +1,231 @@
+@@ -0,0 +1,242 @@
 +#include "os390/os390.h"
 +#include <string.h>
 +#include <sys/stat.h>
@@ -132,6 +132,9 @@ index 0000000..6d4e6c2
 +int orig_mode;
 +int orig_cvstate;
 +
++#include "EXTERN.h"
++#include "perl.h"
++
 +__attribute__((constructor))
 +static void
 +__init()
@@ -193,7 +196,8 @@ index 0000000..6d4e6c2
 +        unsigned int size_libpath_env = strlen(libpath_env);
 +        unsigned int size_colon = sizeof(":");
 +        unsigned int size_lib = sizeof("/lib");
-+        unsigned int total_size = size_parent + size_parent2 + size_libpath_env + size_colon * 2 + size_lib + 1; 
++        unsigned int size_install_lib = sizeof("/lib/perl5/" PERL_VERSION_STRING "/os390/CORE");
++        unsigned int total_size = size_parent + size_parent2*2 + size_libpath_env + size_colon * 3 + size_lib + 1 + size_install_lib + 1; 
 +
 +        char* libpath = (char*)malloc(total_size);
 +        memset(libpath, 0, total_size);
@@ -213,9 +217,16 @@ index 0000000..6d4e6c2
 +        strncat(libpath, ":", total_size);
 +        total_size -= size_colon;
 +
++        strncat(libpath, parent2, total_size);
++        total_size -= size_parent2;
++
++        strncat(libpath, "/lib/perl5/" PERL_VERSION_STRING "/os390/CORE", total_size);
++        total_size -= size_install_lib;
++
 +        strncat(libpath, libpath_env, total_size);
 +        total_size -= size_libpath_env;
 +
++        fprintf(stderr, "Libpath: |%s|\n", libpath);
 +        setenv("LIBPATH", libpath, 1);
 +
 +        free(libpath);

--- a/blead/patches/002.patch
+++ b/blead/patches/002.patch
@@ -1,9 +1,9 @@
 diff --git a/os390/os390.c b/os390/os390.c
 new file mode 100644
-index 0000000..5d8f7dc
+index 0000000..5b16031
 --- /dev/null
 +++ b/os390/os390.c
-@@ -0,0 +1,242 @@
+@@ -0,0 +1,244 @@
 +#include "os390/os390.h"
 +#include <string.h>
 +#include <sys/stat.h>
@@ -196,8 +196,8 @@ index 0000000..5d8f7dc
 +        unsigned int size_libpath_env = strlen(libpath_env);
 +        unsigned int size_colon = sizeof(":");
 +        unsigned int size_lib = sizeof("/lib");
-+        unsigned int size_install_lib = sizeof("/lib/perl5/" PERL_VERSION_STRING "/os390/CORE");
-+        unsigned int total_size = size_parent + size_parent2*2 + size_libpath_env + size_colon * 3 + size_lib + 1 + size_install_lib + 1; 
++        unsigned int size_install_lib = sizeof("/lib/" PERL_VERSION_STRING "/os390/CORE");
++        unsigned int total_size = size_parent + size_parent2*2 + size_libpath_env + size_colon * 4 + size_lib + 1 + size_install_lib + 1; 
 +
 +        char* libpath = (char*)malloc(total_size);
 +        memset(libpath, 0, total_size);
@@ -223,10 +223,12 @@ index 0000000..5d8f7dc
 +        strncat(libpath, "/lib/perl5/" PERL_VERSION_STRING "/os390/CORE", total_size);
 +        total_size -= size_install_lib;
 +
++        strncat(libpath, ":", total_size);
++        total_size -= size_colon;
++
 +        strncat(libpath, libpath_env, total_size);
 +        total_size -= size_libpath_env;
 +
-+        fprintf(stderr, "Libpath: |%s|\n", libpath);
 +        setenv("LIBPATH", libpath, 1);
 +
 +        free(libpath);


### PR DESCRIPTION
* Create an initial README for installation that we can ship with the pax download
* Determine number of build jobs using cpu count, we can override with $PERL_NUM_JOBS
* Add "lib/perl5/" PERL_VERSION_STRING "/os390/CORE" as a search path for the libperl.so