### PR TITLE
make the perl install relocatable

### DIFF
--- a/bin/perlbuild.sh
+++ b/bin/perlbuild.sh
@@ -62,7 +62,7 @@ if [ $? -gt 0 ]; then
   echo "Install directory $install_dir cannot be created"
   exit 16
 fi
-ConfigOpts="-Dprefix=$install_dir"
+ConfigOpts="-Dprefix=$install_dir -Duserelocatableinc"
 
 echo "Extra configure options: $ConfigOpts"
 case "$PERL_VRM" in

--- a/blead/patches/001.patch
+++ b/blead/patches/001.patch
@@ -10,19 +10,6 @@ index 309de23..1d0c3d8 100644
  *.a
  *.so
  *.i
-diff --git a/Configure b/Configure
-index bd96249..2c81e93 100755
---- a/Configure
-+++ b/Configure
-@@ -4566,7 +4566,7 @@ echo "Checking for GNU cc in disguise and/or its version number..." >&4
- $cat >try.c <<EOM
- #include <stdio.h>
- int main() {
--#if defined(__GNUC__) && !defined(__INTEL_COMPILER)
-+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__MVS__)
- #ifdef __VERSION__
- 	printf("%s\n", __VERSION__);
- #else
 diff --git a/cpan/Encode/Makefile.PL b/cpan/Encode/Makefile.PL
 index 632d736..266bb7c 100644
 --- a/cpan/Encode/Makefile.PL
@@ -173,88 +160,6 @@ index 552a106..a72a7c8 100644
  #ifdef PERL_MICRO
  #   include "uconfig.h"
  #else
-diff --git a/util.c b/util.c
-index b1da8e3..9fe743e 100644
---- a/util.c
-+++ b/util.c
-@@ -2646,22 +2646,6 @@ Perl_unlnk(pTHX_ const char *f)	/* unlink all versions of a file */
- }
- #endif
- 
--#if defined(OEMVS)
--  #if (__CHARSET_LIB == 1)
--  static int chgfdccsid(int fd, unsigned short ccsid) 
--  {
--    attrib_t attr;
--    memset(&attr, 0, sizeof(attr));
--    attr.att_filetagchg = 1;
--    attr.att_filetag.ft_ccsid = ccsid;
--    if (ccsid != FT_BINARY) {
--      attr.att_filetag.ft_txtflag = 1;
--    }
--    return __fchattr(fd, &attr, sizeof(attr));
--  }
--  #endif
--#endif
--
- PerlIO *
- Perl_my_popen_list(pTHX_ const char *mode, int n, SV **args)
- {
-@@ -2709,12 +2693,6 @@ Perl_my_popen_list(pTHX_ const char *mode, int n, SV **args)
-         /* Close parent's end of error status pipe (if any) */
-         if (did_pipes)
-             PerlLIO_close(pp[0]);
--#if defined(OEMVS)
--  #if (__CHARSET_LIB == 1)
--        chgfdccsid(p[THIS], 819);
--        chgfdccsid(p[THAT], 819);
--  #endif
--#endif
-         /* Now dup our end of _the_ pipe to right position */
-         if (p[THIS] != (*mode == 'r')) {
-             PerlLIO_dup2(p[THIS], *mode == 'r');
-@@ -2790,19 +2768,7 @@ Perl_my_popen_list(pTHX_ const char *mode, int n, SV **args)
-     }
-     if (did_pipes)
-          PerlLIO_close(pp[0]);
--#if defined(OEMVS)
--  #if (__CHARSET_LIB == 1)
--    PerlIO* io = PerlIO_fdopen(p[This], mode);
--    if (io) {
--      chgfdccsid(p[This], 819);
--    }
--    return io;
--  #else
--    return PerlIO_fdopen(p[This], mode);
--  #endif
--#else
-     return PerlIO_fdopen(p[This], mode);
--#endif
- 
- #else
- #  if defined(OS2)	/* Same, without fork()ing and all extra overhead... */
-@@ -2870,12 +2836,6 @@ Perl_my_popen(pTHX_ const char *cmd, const char *mode)
- #define THAT This
-         if (did_pipes)
-             PerlLIO_close(pp[0]);
--#if defined(OEMVS)
--  #if (__CHARSET_LIB == 1)
--        chgfdccsid(p[THIS], 819);
--        chgfdccsid(p[THAT], 819);
--  #endif
--#endif
-         if (p[THIS] != (*mode == 'r')) {
-             PerlLIO_dup2(p[THIS], *mode == 'r');
-             PerlLIO_close(p[THIS]);
-@@ -2966,7 +2926,7 @@ Perl_my_popen(pTHX_ const char *cmd, const char *mode)
-   #if (__CHARSET_LIB == 1)
-     PerlIO* io = PerlIO_fdopen(p[This],	mode);
-     if (io) {
--      chgfdccsid(p[This], 819);
-+      __chgfdccsid(p[This], 819);
-     }
-     return io;
-   #else
 diff --git a/iperlsys.h b/iperlsys.h
 index b922af0..daed107 100644
 --- a/iperlsys.h
@@ -283,3 +188,117 @@ index b922af0..daed107 100644
  #  define PerlLIO_read(fd, buf, count)  read((fd), (buf), (count))
  #  define PerlLIO_rename(old, new)      rename((old), (new))
  #  define PerlLIO_setmode(fd, mode)     setmode((fd), (mode))
+diff --git a/util.c b/util.c
+index ca7d374..a902360 100644
+--- a/util.c
++++ b/util.c
+@@ -2646,22 +2646,6 @@ Perl_unlnk(pTHX_ const char *f)	/* unlink all versions of a file */
+ }
+ #endif
+ 
+-#if defined(OEMVS)
+-  #if (__CHARSET_LIB == 1)
+-  static int chgfdccsid(int fd, unsigned short ccsid) 
+-  {
+-    attrib_t attr;
+-    memset(&attr, 0, sizeof(attr));
+-    attr.att_filetagchg = 1;
+-    attr.att_filetag.ft_ccsid = ccsid;
+-    if (ccsid != FT_BINARY) {
+-      attr.att_filetag.ft_txtflag = 1;
+-    }
+-    return __fchattr(fd, &attr, sizeof(attr));
+-  }
+-  #endif
+-#endif
+-
+ /*
+ =for apidoc my_popen_list
+ 
+@@ -2717,12 +2701,6 @@ Perl_my_popen_list(pTHX_ const char *mode, int n, SV **args)
+         /* Close parent's end of error status pipe (if any) */
+         if (did_pipes)
+             PerlLIO_close(pp[0]);
+-#if defined(OEMVS)
+-  #if (__CHARSET_LIB == 1)
+-        chgfdccsid(p[THIS], 819);
+-        chgfdccsid(p[THAT], 819);
+-  #endif
+-#endif
+         /* Now dup our end of _the_ pipe to right position */
+         if (p[THIS] != (*mode == 'r')) {
+             PerlLIO_dup2(p[THIS], *mode == 'r');
+@@ -2798,19 +2776,7 @@ Perl_my_popen_list(pTHX_ const char *mode, int n, SV **args)
+     }
+     if (did_pipes)
+          PerlLIO_close(pp[0]);
+-#if defined(OEMVS)
+-  #if (__CHARSET_LIB == 1)
+-    PerlIO* io = PerlIO_fdopen(p[This], mode);
+-    if (io) {
+-      chgfdccsid(p[This], 819);
+-    }
+-    return io;
+-  #else
+-    return PerlIO_fdopen(p[This], mode);
+-  #endif
+-#else
+     return PerlIO_fdopen(p[This], mode);
+-#endif
+ 
+ #else
+ #  if defined(OS2)	/* Same, without fork()ing and all extra overhead... */
+@@ -2889,12 +2855,6 @@ Perl_my_popen(pTHX_ const char *cmd, const char *mode)
+ #define THAT This
+         if (did_pipes)
+             PerlLIO_close(pp[0]);
+-#if defined(OEMVS)
+-  #if (__CHARSET_LIB == 1)
+-        chgfdccsid(p[THIS], 819);
+-        chgfdccsid(p[THAT], 819);
+-  #endif
+-#endif
+         if (p[THIS] != (*mode == 'r')) {
+             PerlLIO_dup2(p[THIS], *mode == 'r');
+             PerlLIO_close(p[THIS]);
+@@ -2985,7 +2945,7 @@ Perl_my_popen(pTHX_ const char *cmd, const char *mode)
+   #if (__CHARSET_LIB == 1)
+     PerlIO* io = PerlIO_fdopen(p[This],	mode);
+     if (io) {
+-      chgfdccsid(p[This], 819);
++      __chgfdccsid(p[This], 819);
+     }
+     return io;
+   #else
+diff --git a/Configure b/Configure
+index bd96249..28f19c0 100755
+--- a/Configure
++++ b/Configure
+@@ -4566,7 +4566,7 @@ echo "Checking for GNU cc in disguise and/or its version number..." >&4
+ $cat >try.c <<EOM
+ #include <stdio.h>
+ int main() {
+-#if defined(__GNUC__) && !defined(__INTEL_COMPILER)
++#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__MVS__)
+ #ifdef __VERSION__
+ 	printf("%s\n", __VERSION__);
+ #else
+@@ -8726,10 +8726,14 @@ case "$useshrplib" in
+ true)
+ 	case "$userelocatableinc" in
+ 	true|define)
+-		echo "Cannot build with both -Duserelocatableinc and -Duseshrplib" >&4
+-		echo "See INSTALL for an explanation why that won't work." >&4
+-		exit 4
+-		;;
++    case "$osname" in
++      os390) ;;
++      *)
++        echo "Cannot build with both -Duserelocatableinc and -Duseshrplib" >&4
++        echo "See INSTALL for an explanation why that won't work." >&4
++        exit 4
++        ;;
++    esac
+ 	esac
+ 	case "$libperl" in
+ 	'')

--- a/blead/patches/001.patch
+++ b/blead/patches/001.patch
@@ -271,7 +271,7 @@ index ca7d374..a902360 100644
      return io;
    #else
 diff --git a/Configure b/Configure
-index bd96249..28f19c0 100755
+index bd96249..53e8787 100755
 --- a/Configure
 +++ b/Configure
 @@ -4566,7 +4566,7 @@ echo "Checking for GNU cc in disguise and/or its version number..." >&4
@@ -279,7 +279,7 @@ index bd96249..28f19c0 100755
  #include <stdio.h>
  int main() {
 -#if defined(__GNUC__) && !defined(__INTEL_COMPILER)
-+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__MVS__)
++#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && !defined(__MVS__) /* xlclang sets __GNUC__ but does not set __VERSION__ */
  #ifdef __VERSION__
  	printf("%s\n", __VERSION__);
  #else
@@ -292,7 +292,7 @@ index bd96249..28f19c0 100755
 -		exit 4
 -		;;
 +    case "$osname" in
-+      os390) ;;
++      os390) echo "Perl on z/OS uses LIBPATH to dynamically locate shared objects." ;;
 +      *)
 +        echo "Cannot build with both -Duserelocatableinc and -Duseshrplib" >&4
 +        echo "See INSTALL for an explanation why that won't work." >&4

--- a/blead/patches/003.patch
+++ b/blead/patches/003.patch
@@ -1,5 +1,5 @@
 diff --git a/hints/os390.sh b/hints/os390.sh
-index 8995d8c..cea9023 100644
+index 8995d8c..97ccc57 100644
 --- a/hints/os390.sh
 +++ b/hints/os390.sh
 @@ -18,23 +18,10 @@
@@ -84,16 +84,17 @@ index 8995d8c..cea9023 100644
  
  def_os390_defs="$def_os390_defs -DMAXSIG=39 -DNSIG=39";     # maximum signal number; not furnished by IBM
  def_os390_defs="$def_os390_defs -DOEMVS";   # is used in place of #ifdef __MVS__
-@@ -96,6 +110,8 @@ def_os390_defs="$def_os390_defs -DNO_LOCALE_MESSAGES"
+@@ -96,6 +110,9 @@ def_os390_defs="$def_os390_defs -DNO_LOCALE_MESSAGES"
  # Set up feature test macros required for features available on supported z/OS systems
  def_os390_defs="$def_os390_defs -D_OPEN_THREADS=3 -D_UNIX03_SOURCE=1 -D_AE_BIMODAL=1 -D_XOPEN_SOURCE_EXTENDED -D_ALL_SOURCE -D_ENHANCED_ASCII_EXT=0xFFFFFFFF -D_OPEN_SYS_FILE_EXT=1 -D_OPEN_SYS_SOCK_IPV6 -D_XOPEN_SOURCE=600 -D_XOPEN_SOURCE_EXTENDED"
  
++# Find perl base on PATH environment variable rather than hardcoding install location
 +startperl='#!/bin/env perl'
 +
  # Combine -D with cflags
  case "$ccflags" in
  '') ccflags="$def_os390_cflags $def_os390_defs"  ;;
-@@ -234,10 +250,10 @@ esac
+@@ -234,10 +251,10 @@ esac
  # NOLOC says to use the 1047 code page, and no locale
  case "$usedl" in
  define)

--- a/blead/patches/003.patch
+++ b/blead/patches/003.patch
@@ -1,5 +1,5 @@
 diff --git a/hints/os390.sh b/hints/os390.sh
-index 8995d8c..6e7098d 100644
+index 8995d8c..cea9023 100644
 --- a/hints/os390.sh
 +++ b/hints/os390.sh
 @@ -18,23 +18,10 @@
@@ -84,7 +84,16 @@ index 8995d8c..6e7098d 100644
  
  def_os390_defs="$def_os390_defs -DMAXSIG=39 -DNSIG=39";     # maximum signal number; not furnished by IBM
  def_os390_defs="$def_os390_defs -DOEMVS";   # is used in place of #ifdef __MVS__
-@@ -234,10 +248,10 @@ esac
+@@ -96,6 +110,8 @@ def_os390_defs="$def_os390_defs -DNO_LOCALE_MESSAGES"
+ # Set up feature test macros required for features available on supported z/OS systems
+ def_os390_defs="$def_os390_defs -D_OPEN_THREADS=3 -D_UNIX03_SOURCE=1 -D_AE_BIMODAL=1 -D_XOPEN_SOURCE_EXTENDED -D_ALL_SOURCE -D_ENHANCED_ASCII_EXT=0xFFFFFFFF -D_OPEN_SYS_FILE_EXT=1 -D_OPEN_SYS_SOCK_IPV6 -D_XOPEN_SOURCE=600 -D_XOPEN_SOURCE_EXTENDED"
+ 
++startperl='#!/bin/env perl'
++
+ # Combine -D with cflags
+ case "$ccflags" in
+ '') ccflags="$def_os390_cflags $def_os390_defs"  ;;
+@@ -234,10 +250,10 @@ esac
  # NOLOC says to use the 1047 code page, and no locale
  case "$usedl" in
  define)


### PR DESCRIPTION
- Adds  -Duserelocatableinc
- Also sets `startperl='#!/bin/env perl'` so that it is dynamic rather than an absolute location
- Fixes a few patches that no longer merged properly