### PR TITLE
Fix typo in perl.h (general bug for everyone?)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+log/
+perl5/

--- a/patches/PR1/consolidate_os390_changes.patch
+++ b/patches/PR1/consolidate_os390_changes.patch
@@ -569,21 +569,6 @@ index e90b4ae..091c6e3 100644
      int exitstatus, i;
  #ifndef NO_ENV_ARRAY_IN_MAIN
      PERL_UNUSED_ARG(env);
-diff --git a/perl.h b/perl.h
-index 552a106..a72a7c8 100644
---- a/perl.h
-+++ b/perl.h
-@@ -22,6 +22,10 @@
- #define USE_STDIO
- #endif /* PERL_FOR_X2P */
- 
-+#if defined(__MVS__)
-+#   include "os390/os390.h"
-+#endif
-+
- #ifdef PERL_MICRO
- #   include "uconfig.h"
- #else
 diff --git a/iperlsys.h b/iperlsys.h
 index b922af0..daed107 100644
 --- a/iperlsys.h

--- a/patches/PR3/perl.h.patch
+++ b/patches/PR3/perl.h.patch
@@ -1,0 +1,24 @@
+diff --git a/perl.h b/perl.h
+index 8116144db1..c153fd704e 100644
+--- a/perl.h
++++ b/perl.h
+@@ -22,6 +22,10 @@
+ #define USE_STDIO
+ #endif /* PERL_FOR_X2P */
+ 
++#if defined(__MVS__)
++#   include "os390/os390.h"
++#endif
++
+ #ifdef PERL_MICRO
+ #   include "uconfig.h"
+ #else
+@@ -1213,7 +1217,7 @@ violations are fatal.
+ #    define PERL_DUMMY_NAME_            PERL_DUMMY_TELEPHONE_
+ #  endif
+ #  ifdef USE_LOCALE_SYNTAX
+-#    define LC_SYNTAX_INDEX_            PERL_DUMMY_NAME + 1
++#    define LC_SYNTAX_INDEX_            PERL_DUMMY_NAME_ + 1
+ #    define PERL_DUMMY_SYNTAX_          LC_SYNTAX_INDEX_
+ #  else
+ #    define PERL_DUMMY_SYNTAX_          PERL_DUMMY_NAME_


### PR DESCRIPTION
remove perl.h patch from consolidate patches and put into PR3 along with typo fixup
fixes #55 