### PR TITLE
Reinstate old patch, needed to avoid double conversion

### DIFF
--- a/patches/PR1.patch
+++ b/patches/PR1.patch
@@ -174,9 +174,9 @@ index 48deb13d6a..789bd1ff76 100644
            doshell:
              PERL_FPU_PRE_EXEC
 +#if defined(OEMVS)
-+ // #if (__CHARSET_LIB == 1)
-+ //           unsetenv("_TAG_REDIR_ERR");
-+ // #endif
++  #if (__CHARSET_LIB == 1)
++            unsetenv("_TAG_REDIR_ERR");
++  #endif
 +#endif
              PerlProc_execl(PL_sh_path, "sh", "-c", cmd, (char *)NULL);
              PERL_FPU_POST_EXEC


### PR DESCRIPTION
* When adding the dependency zoslib I incorrectly undid this patch, but removing it had a negative impact on GNU Make's tests. Reinstating it here.