### PR TITLE
Add PERL5LIB back to env

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -12,6 +12,14 @@ export ZOPEN_COMP=CLANG
 export INSTALLFLAGS="+v"
 
 zopen_append_to_env() {
+cat <<EOF
+if ls \${PWD}/lib/perl[0-9]* >/dev/null 2>&1; then
+  PERL5LIB_ROOT=\$( cd \${PWD}/lib/perl[0-9]/[0-9]*; echo \$PWD )
+else
+  PERL5LIB_ROOT=\$( cd \${PWD}/lib/[0-9]*; echo \$PWD )
+fi
+export PERL5LIB="\${PERL5LIB_ROOT}:\${PERL5LIB_ROOT}/os390"
+EOF
 }
 
 zopen_append_to_zoslib_env() {


### PR DESCRIPTION
Add PERL5LIB back in until we figure out why zopen build has issues without it.