### PR TITLE
Remove PERL5LIB from env

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -11,17 +11,6 @@ export ZOPEN_COMP=CLANG
 # Perl Environment variables
 export INSTALLFLAGS="+v"
 
-zopen_append_to_env() {
-cat <<EOF
-if ls \${PWD}/lib/perl[0-9]* >/dev/null 2>&1; then
-  PERL5LIB_ROOT=\$( cd \${PWD}/lib/perl[0-9]/[0-9]*; echo \$PWD )
-else
-  PERL5LIB_ROOT=\$( cd \${PWD}/lib/[0-9]*; echo \$PWD )
-fi
-export PERL5LIB="\${PERL5LIB_ROOT}:\${PERL5LIB_ROOT}/os390"
-EOF
-}
-
 zopen_append_to_zoslib_env() {
 cat <<EOF
 PERL5LIB|set|PROJECT_ROOT/lib/$PERL_VERSION/:PROJECT_ROOT/lib/$PERL_VERSION/os390/


### PR DESCRIPTION
The earlier issues with PERL5LIB should now be resolved thanks to https://github.com/ZOSOpenTools/meta/pull/517. This means we can remove it from the .env/.appenv envars.