### PR TITLE
Fix copy: Use stat instead of fstat and move copytags call before write

### DIFF
--- a/patches/PR1/lib/File/Copy.pm.patch
+++ b/patches/PR1/lib/File/Copy.pm.patch
@@ -1,16 +1,16 @@
 diff --git a/lib/File/Copy.pm b/lib/File/Copy.pm
-index 1dc1d2d95c..6210af4cbe 100644
+index 1dc1d2d95c..4cab268469 100644
 --- a/lib/File/Copy.pm
 +++ b/lib/File/Copy.pm
-@@ -180,6 +180,11 @@ sub copy {
- 	}
+@@ -168,6 +168,11 @@ sub copy {
+ 	$closeto = 1;
      }
  
 +    # Copy file tags on os390
 +    if ($^O eq 'os390') {
-+      ZOS::Filespec::copytags(fileno($from_h), fileno($to_h));
++      ZOS::Filespec::copytags_fd(fileno($from_h), fileno($to_h));
 +    }
 +
-     close($to_h) || goto fail_open2 if $closeto;
-     close($from_h) || goto fail_open1 if $closefrom;
- 
+     $! = 0;
+     for (;;) {
+ 	my ($r, $w, $t);

--- a/patches/PR1/os390/os390.c.patch
+++ b/patches/PR1/os390/os390.c.patch
@@ -1,9 +1,9 @@
 diff --git a/os390/os390.c b/os390/os390.c
 new file mode 100644
-index 0000000000..22b95204eb
+index 0000000000..9a627ab6ea
 --- /dev/null
 +++ b/os390/os390.c
-@@ -0,0 +1,51 @@
+@@ -0,0 +1,56 @@
 +#include <string.h>
 +#include <sys/stat.h>
 +#include <stdio.h>
@@ -16,25 +16,31 @@ index 0000000000..22b95204eb
 +#include <_Nascii.h>
 +#include <fcntl.h>
 +#include <libgen.h>
++#include <termios.h>
 +#include "EXTERN.h"
 +#include "perl.h"
 +#include "XSUB.h"
 +
 +void
-+zos_copytags(pTHX_ CV *cv)
++zos_copytags_fd(pTHX_ CV *cv)
 +{
 +  dXSARGS;
-+  STRLEN n_a;
 +  int ret = 0;
 +
 +  if (items != 2)
-+    Perl_croak(aTHX_ "Usage: ZOS::Filespec::copytags(f1, f2])");
++    Perl_croak(aTHX_ "Usage: ZOS::Filespec::copytags_fd(f1, f2])");
 +
 +  int from_fd = (int)SvIV(ST(0));
 +  int to_fd = (int)SvIV(ST(1));
 +
++  char path[_XOPEN_PATH_MAX] = {0};
++  int rc = w_ioctl(from_fd, _IOCC_GPN, _XOPEN_PATH_MAX, path);
++  if (rc == 0) {
++    __e2a_l(path, _XOPEN_PATH_MAX);
++  }
++
 +  struct stat src_statsbuf;
-+  if (fstat(from_fd, &src_statsbuf)) {
++  if (stat(path, &src_statsbuf)) {
 +    ret = -1;
 +  }
 +  if (ret != -1) {
@@ -44,14 +50,13 @@ index 0000000000..22b95204eb
 +  XSRETURN(ret);
 +}
 +
-+
 +void
 +init_os_extras(void)
 +{
 +  dTHX;
 +  char* file = __FILE__;
 +
-+  newXSproto("ZOS::Filespec::copytags",zos_copytags,file,"$;$");
++  newXSproto("ZOS::Filespec::copytags_fd",zos_copytags_fd,file,"$;$");
 +
 +  return;
 +}


### PR DESCRIPTION
Fix for https://github.com/ZOSOpenTools/perlport/issues/85