### PR TITLE
Update stable dependencies in buildenv

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -2,7 +2,7 @@
 PERL_VERSION="5.43.10"
 
 export ZOPEN_BUILD_LINE="STABLE"
-export ZOPEN_STABLE_DEPS="curl gzip make git make zoslib sed coreutils grep findutils zlib gettext"
+export ZOPEN_STABLE_DEPS="make zoslib sed coreutils grep findutils zlib gettext"
 export ZOPEN_STABLE_URL="https://github.com/Perl/perl5.git"
 export ZOPEN_STABLE_TAG="v${PERL_VERSION}"
 # export ZOPEN_STABLE_URL="https://github.com/Perl/perl5/archive/refs/tags/v${PERL_VERSION}.tar.gz"


### PR DESCRIPTION
Removed 'curl' and 'gzip' from the stable dependencies to streamline the build environment.